### PR TITLE
feat: forbid anonymous GraphQL endpoints

### DIFF
--- a/Mindbox.Analyzers.Tests/UnitTests.cs
+++ b/Mindbox.Analyzers.Tests/UnitTests.cs
@@ -393,13 +393,26 @@ public class UnitTest : CodeFixVerifier
 		var test = @"
 			public static class GraphQlEndpointExtensions
 			{
-				public static GraphQlEndpointConventionBuilder MapGraphQL(this object builder) => new GraphQlEndpointConventionBuilder();
+				public static GraphQlEndpointConventionBuilder MapGraphQL(
+					this object builder)
+				{
+					return new GraphQlEndpointConventionBuilder();
+				}
 			}
 
 			public static class AuthorizationExtensions
 			{
-				public static GraphQlEndpointConventionBuilder AllowAnonymous(this GraphQlEndpointConventionBuilder builder) => builder;
-				public static GraphQlEndpointConventionBuilder RequireAuthorization(this GraphQlEndpointConventionBuilder builder) => builder;
+				public static GraphQlEndpointConventionBuilder AllowAnonymous(
+					this GraphQlEndpointConventionBuilder builder)
+				{
+					return builder;
+				}
+
+				public static GraphQlEndpointConventionBuilder RequireAuthorization(
+					this GraphQlEndpointConventionBuilder builder)
+				{
+					return builder;
+				}
 			}
 
 			public class GraphQlEndpointConventionBuilder
@@ -422,7 +435,7 @@ public class UnitTest : CodeFixVerifier
 			Severity = DiagnosticSeverity.Warning,
 			Locations = new[]
 			{
-				new DiagnosticResultLocation("Test0.cs", 20, 6)
+				new DiagnosticResultLocation("Test0.cs", 31, 6)
 			}
 		};
 
@@ -435,13 +448,26 @@ public class UnitTest : CodeFixVerifier
 		var test = @"
 			public static class GraphQlEndpointExtensions
 			{
-				public static GraphQlEndpointConventionBuilder MapGraphQL(this object builder) => new GraphQlEndpointConventionBuilder();
+				public static GraphQlEndpointConventionBuilder MapGraphQL(
+					this object builder)
+				{
+					return new GraphQlEndpointConventionBuilder();
+				}
 			}
 
 			public static class AuthorizationExtensions
 			{
-				public static GraphQlEndpointConventionBuilder AllowAnonymous(this GraphQlEndpointConventionBuilder builder) => builder;
-				public static GraphQlEndpointConventionBuilder RequireAuthorization(this GraphQlEndpointConventionBuilder builder) => builder;
+				public static GraphQlEndpointConventionBuilder AllowAnonymous(
+					this GraphQlEndpointConventionBuilder builder)
+				{
+					return builder;
+				}
+
+				public static GraphQlEndpointConventionBuilder RequireAuthorization(
+					this GraphQlEndpointConventionBuilder builder)
+				{
+					return builder;
+				}
 			}
 
 			public class GraphQlEndpointConventionBuilder
@@ -465,12 +491,20 @@ public class UnitTest : CodeFixVerifier
 		var test = @"
 			public static class GraphQlEndpointExtensions
 			{
-				public static GraphQlEndpointConventionBuilder MapGraphQL(this object builder) => new GraphQlEndpointConventionBuilder();
+				public static GraphQlEndpointConventionBuilder MapGraphQL(
+					this object builder)
+				{
+					return new GraphQlEndpointConventionBuilder();
+				}
 			}
 
 			public static class AuthorizationExtensions
 			{
-				public static GraphQlEndpointConventionBuilder AllowAnonymous(this GraphQlEndpointConventionBuilder builder) => builder;
+				public static GraphQlEndpointConventionBuilder AllowAnonymous(
+					this GraphQlEndpointConventionBuilder builder)
+				{
+					return builder;
+				}
 			}
 
 			public class GraphQlEndpointConventionBuilder
@@ -494,7 +528,7 @@ public class UnitTest : CodeFixVerifier
 			Severity = DiagnosticSeverity.Warning,
 			Locations = new[]
 			{
-				new DiagnosticResultLocation("Test0.cs", 20, 6)
+				new DiagnosticResultLocation("Test0.cs", 25, 6)
 			}
 		};
 
@@ -507,13 +541,26 @@ public class UnitTest : CodeFixVerifier
 		var test = @"
 			public static class GraphQlEndpointExtensions
 			{
-				public static GraphQlEndpointConventionBuilder MapGraphQL(this object builder) => new GraphQlEndpointConventionBuilder();
-				public static GraphQlEndpointConventionBuilder RequireCors(this GraphQlEndpointConventionBuilder builder) => builder;
+				public static GraphQlEndpointConventionBuilder MapGraphQL(
+					this object builder)
+				{
+					return new GraphQlEndpointConventionBuilder();
+				}
+
+				public static GraphQlEndpointConventionBuilder RequireCors(
+					this GraphQlEndpointConventionBuilder builder)
+				{
+					return builder;
+				}
 			}
 
 			public static class AuthorizationExtensions
 			{
-				public static GraphQlEndpointConventionBuilder AllowAnonymous(this GraphQlEndpointConventionBuilder builder) => builder;
+				public static GraphQlEndpointConventionBuilder AllowAnonymous(
+					this GraphQlEndpointConventionBuilder builder)
+				{
+					return builder;
+				}
 			}
 
 			public class GraphQlEndpointConventionBuilder
@@ -538,7 +585,7 @@ public class UnitTest : CodeFixVerifier
 			Severity = DiagnosticSeverity.Warning,
 			Locations = new[]
 			{
-				new DiagnosticResultLocation("Test0.cs", 22, 6)
+				new DiagnosticResultLocation("Test0.cs", 31, 6)
 			}
 		};
 
@@ -551,12 +598,20 @@ public class UnitTest : CodeFixVerifier
 		var test = @"
 			public static class EndpointExtensions
 			{
-				public static HttpEndpointConventionBuilder MapGet(this object builder) => new HttpEndpointConventionBuilder();
+				public static HttpEndpointConventionBuilder MapGet(
+					this object builder)
+				{
+					return new HttpEndpointConventionBuilder();
+				}
 			}
 
 			public static class AuthorizationExtensions
 			{
-				public static HttpEndpointConventionBuilder AllowAnonymous(this HttpEndpointConventionBuilder builder) => builder;
+				public static HttpEndpointConventionBuilder AllowAnonymous(
+					this HttpEndpointConventionBuilder builder)
+				{
+					return builder;
+				}
 			}
 
 			public class HttpEndpointConventionBuilder

--- a/Mindbox.Analyzers.Tests/UnitTests.cs
+++ b/Mindbox.Analyzers.Tests/UnitTests.cs
@@ -435,7 +435,7 @@ public class UnitTest : CodeFixVerifier
 			Severity = DiagnosticSeverity.Warning,
 			Locations = new[]
 			{
-				new DiagnosticResultLocation("Test0.cs", 31, 6)
+				new DiagnosticResultLocation("Test0.cs", 34, 6)
 			}
 		};
 
@@ -528,7 +528,7 @@ public class UnitTest : CodeFixVerifier
 			Severity = DiagnosticSeverity.Warning,
 			Locations = new[]
 			{
-				new DiagnosticResultLocation("Test0.cs", 25, 6)
+				new DiagnosticResultLocation("Test0.cs", 29, 6)
 			}
 		};
 
@@ -585,7 +585,7 @@ public class UnitTest : CodeFixVerifier
 			Severity = DiagnosticSeverity.Warning,
 			Locations = new[]
 			{
-				new DiagnosticResultLocation("Test0.cs", 31, 6)
+				new DiagnosticResultLocation("Test0.cs", 36, 6)
 			}
 		};
 

--- a/Mindbox.Analyzers.Tests/UnitTests.cs
+++ b/Mindbox.Analyzers.Tests/UnitTests.cs
@@ -386,6 +386,194 @@ public class UnitTest : CodeFixVerifier
 		VerifyCSharpDiagnostic(test, expected);
 	}
 	*/
+
+	[TestMethod]
+	public void GraphQlEndpointAllowAnonymous_ProducesDiagnostic()
+	{
+		var test = @"
+			public static class GraphQlEndpointExtensions
+			{
+				public static GraphQlEndpointConventionBuilder MapGraphQL(this object builder) => new GraphQlEndpointConventionBuilder();
+			}
+
+			public static class AuthorizationExtensions
+			{
+				public static GraphQlEndpointConventionBuilder AllowAnonymous(this GraphQlEndpointConventionBuilder builder) => builder;
+				public static GraphQlEndpointConventionBuilder RequireAuthorization(this GraphQlEndpointConventionBuilder builder) => builder;
+			}
+
+			public class GraphQlEndpointConventionBuilder
+			{
+			}
+
+			public class Test
+			{
+				public void Configure(object app)
+				{
+					app.MapGraphQL().AllowAnonymous();
+				}
+			}";
+
+		var rule = new ForbidAnonymousAccessToGraphQlEndpointsRule();
+		var expected = new DiagnosticResult
+		{
+			Id = rule.DiagnosticDescriptor.Id,
+			Message = rule.DiagnosticDescriptor.MessageFormat.ToString(),
+			Severity = DiagnosticSeverity.Warning,
+			Locations = new[]
+			{
+				new DiagnosticResultLocation("Test0.cs", 20, 6)
+			}
+		};
+
+		VerifyCSharpDiagnostic(test, expected);
+	}
+
+	[TestMethod]
+	public void GraphQlEndpointRequireAuthorization_DoesNotProduceDiagnostic()
+	{
+		var test = @"
+			public static class GraphQlEndpointExtensions
+			{
+				public static GraphQlEndpointConventionBuilder MapGraphQL(this object builder) => new GraphQlEndpointConventionBuilder();
+			}
+
+			public static class AuthorizationExtensions
+			{
+				public static GraphQlEndpointConventionBuilder AllowAnonymous(this GraphQlEndpointConventionBuilder builder) => builder;
+				public static GraphQlEndpointConventionBuilder RequireAuthorization(this GraphQlEndpointConventionBuilder builder) => builder;
+			}
+
+			public class GraphQlEndpointConventionBuilder
+			{
+			}
+
+			public class Test
+			{
+				public void Configure(object app)
+				{
+					app.MapGraphQL().RequireAuthorization();
+				}
+			}";
+
+		VerifyCSharpDiagnostic(test);
+	}
+
+	[TestMethod]
+	public void GraphQlEndpointAllowAnonymousThroughVariable_ProducesDiagnostic()
+	{
+		var test = @"
+			public static class GraphQlEndpointExtensions
+			{
+				public static GraphQlEndpointConventionBuilder MapGraphQL(this object builder) => new GraphQlEndpointConventionBuilder();
+			}
+
+			public static class AuthorizationExtensions
+			{
+				public static GraphQlEndpointConventionBuilder AllowAnonymous(this GraphQlEndpointConventionBuilder builder) => builder;
+			}
+
+			public class GraphQlEndpointConventionBuilder
+			{
+			}
+
+			public class Test
+			{
+				public void Configure(object app)
+				{
+					var endpoint = app.MapGraphQL();
+					endpoint.AllowAnonymous();
+				}
+			}";
+
+		var rule = new ForbidAnonymousAccessToGraphQlEndpointsRule();
+		var expected = new DiagnosticResult
+		{
+			Id = rule.DiagnosticDescriptor.Id,
+			Message = rule.DiagnosticDescriptor.MessageFormat.ToString(),
+			Severity = DiagnosticSeverity.Warning,
+			Locations = new[]
+			{
+				new DiagnosticResultLocation("Test0.cs", 20, 6)
+			}
+		};
+
+		VerifyCSharpDiagnostic(test, expected);
+	}
+
+	[TestMethod]
+	public void GraphQlEndpointAllowAnonymousAfterIntermediateVariable_ProducesDiagnostic()
+	{
+		var test = @"
+			public static class GraphQlEndpointExtensions
+			{
+				public static GraphQlEndpointConventionBuilder MapGraphQL(this object builder) => new GraphQlEndpointConventionBuilder();
+				public static GraphQlEndpointConventionBuilder RequireCors(this GraphQlEndpointConventionBuilder builder) => builder;
+			}
+
+			public static class AuthorizationExtensions
+			{
+				public static GraphQlEndpointConventionBuilder AllowAnonymous(this GraphQlEndpointConventionBuilder builder) => builder;
+			}
+
+			public class GraphQlEndpointConventionBuilder
+			{
+			}
+
+			public class Test
+			{
+				public void Configure(object app)
+				{
+					var endpoint = app.MapGraphQL();
+					var endpointWithCors = endpoint.RequireCors();
+					endpointWithCors.AllowAnonymous();
+				}
+			}";
+
+		var rule = new ForbidAnonymousAccessToGraphQlEndpointsRule();
+		var expected = new DiagnosticResult
+		{
+			Id = rule.DiagnosticDescriptor.Id,
+			Message = rule.DiagnosticDescriptor.MessageFormat.ToString(),
+			Severity = DiagnosticSeverity.Warning,
+			Locations = new[]
+			{
+				new DiagnosticResultLocation("Test0.cs", 22, 6)
+			}
+		};
+
+		VerifyCSharpDiagnostic(test, expected);
+	}
+
+	[TestMethod]
+	public void NonGraphQlEndpointAllowAnonymous_DoesNotProduceDiagnostic()
+	{
+		var test = @"
+			public static class EndpointExtensions
+			{
+				public static HttpEndpointConventionBuilder MapGet(this object builder) => new HttpEndpointConventionBuilder();
+			}
+
+			public static class AuthorizationExtensions
+			{
+				public static HttpEndpointConventionBuilder AllowAnonymous(this HttpEndpointConventionBuilder builder) => builder;
+			}
+
+			public class HttpEndpointConventionBuilder
+			{
+			}
+
+			public class Test
+			{
+				public void Configure(object app)
+				{
+					app.MapGet().AllowAnonymous();
+				}
+			}";
+
+		VerifyCSharpDiagnostic(test);
+	}
+
 	protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
 	{
 		return new MindboxAnalyzer();

--- a/Mindbox.Analyzers/MindboxAnalyzer.cs
+++ b/Mindbox.Analyzers/MindboxAnalyzer.cs
@@ -35,7 +35,8 @@ public class MindboxAnalyzer : DiagnosticAnalyzer
 			new DataContractRequireIfUsingDataMemberRule(),
 			new ForbidRawSqlOutsideDbProviderSpecificCodeRule(),
 			new ForbidGroupingByNavigationPropertiesRule(),
-			new KafkaAdminClientCreateTopicsAndPartitionsProhibitedRule()
+			new KafkaAdminClientCreateTopicsAndPartitionsProhibitedRule(),
+			new ForbidAnonymousAccessToGraphQlEndpointsRule()
 		};
 
 		_supportedDiagnostics =

--- a/Mindbox.Analyzers/Rules/DataContractRequireIfUsingDataMemberRule.cs
+++ b/Mindbox.Analyzers/Rules/DataContractRequireIfUsingDataMemberRule.cs
@@ -80,8 +80,8 @@ public class DataContractRequireIfUsingDataMemberRule : AnalyzerRule, ISemanticM
 		public AttributeAnalyzer(SemanticModel model)
 		{
 			_model = model;
-			_dataMemberAttribute ??= model.Compilation.GetTypeByMetadataName(typeof(DataMemberAttribute).FullName!);
-			_dataContractAttribute ??= model.Compilation.GetTypeByMetadataName(typeof(DataContractAttribute).FullName!);
+			_dataMemberAttribute ??= model.Compilation.GetTypeByMetadataName(typeof(DataMemberAttribute).FullName);
+			_dataContractAttribute ??= model.Compilation.GetTypeByMetadataName(typeof(DataContractAttribute).FullName);
 		}
 
 		public bool ContainsDataMemberAttribute(IEnumerable<INamedTypeSymbol> attributes)

--- a/Mindbox.Analyzers/Rules/ForbidAnonymousAccessToGraphQlEndpointsRule.cs
+++ b/Mindbox.Analyzers/Rules/ForbidAnonymousAccessToGraphQlEndpointsRule.cs
@@ -1,0 +1,170 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace MindboxAnalyzers.Rules;
+
+public class ForbidAnonymousAccessToGraphQlEndpointsRule : AnalyzerRule, ISemanticModelAnalyzerRule
+{
+	private const string RuleId = "Mindbox2007";
+	private const string Title = "Forbids anonymous access to GraphQL endpoints.";
+	private const string Message = "GraphQL endpoints must not allow anonymous access. Use RequireAuthorization() instead of AllowAnonymous().";
+	private const string Description =
+		"GraphQL endpoints must be closed for anonymous access. When mapping a GraphQL endpoint, do not call AllowAnonymous(); use RequireAuthorization() instead.";
+
+	public ForbidAnonymousAccessToGraphQlEndpointsRule()
+		: base(
+			ruleId: RuleId,
+			title: Title,
+			messageFormat: Message,
+			description: Description)
+	{
+	}
+
+	public void AnalyzeModel(SemanticModel model, out ICollection<Diagnostic> foundProblems)
+	{
+		foundProblems = model.SyntaxTree
+			.GetRoot()
+			.DescendantNodes()
+			.OfType<InvocationExpressionSyntax>()
+			.Where(invocation => IsAnonymousGraphQlEndpointInvocation(invocation, model))
+			.Select(invocation => CreateDiagnosticForLocation(invocation.GetLocation()))
+			.ToList();
+	}
+
+	private static bool IsAnonymousGraphQlEndpointInvocation(InvocationExpressionSyntax invocation, SemanticModel model)
+	{
+		if (!IsMethodNamed(invocation, "AllowAnonymous"))
+			return false;
+
+		if (GetReceiverExpression(invocation) is not { } receiverExpression)
+			return false;
+
+		return IsGraphQlEndpointExpression(receiverExpression, model, new HashSet<ISymbol>(SymbolEqualityComparer.Default));
+	}
+
+	private static bool IsGraphQlEndpointExpression(
+		ExpressionSyntax expression,
+		SemanticModel model,
+		HashSet<ISymbol> visitedSymbols)
+	{
+		expression = Unwrap(expression);
+
+		switch (expression)
+		{
+			case InvocationExpressionSyntax invocation:
+				if (IsMethodNamed(invocation, "MapGraphQL"))
+					return true;
+
+				return GetReceiverExpression(invocation) is { } invocationReceiver
+					&& IsGraphQlEndpointExpression(invocationReceiver, model, visitedSymbols);
+
+			case IdentifierNameSyntax:
+			case MemberAccessExpressionSyntax:
+				return TryResolveAssignedGraphQlEndpoint(expression, model, visitedSymbols);
+
+			case ConditionalAccessExpressionSyntax conditionalAccess:
+				return IsGraphQlEndpointExpression(conditionalAccess.Expression, model, visitedSymbols);
+
+			default:
+				return false;
+		}
+	}
+
+	private static bool TryResolveAssignedGraphQlEndpoint(
+		ExpressionSyntax expression,
+		SemanticModel model,
+		HashSet<ISymbol> visitedSymbols)
+	{
+		var symbol = model.GetSymbolInfo(expression).Symbol;
+		if (symbol == null || !visitedSymbols.Add(symbol))
+			return false;
+
+		foreach (var assignedExpression in GetAssignedExpressions(symbol, expression.SyntaxTree.GetRoot(), model))
+		{
+			if (IsGraphQlEndpointExpression(assignedExpression, model, visitedSymbols))
+				return true;
+		}
+
+		return false;
+	}
+
+	private static IEnumerable<ExpressionSyntax> GetAssignedExpressions(ISymbol symbol, SyntaxNode root, SemanticModel model)
+	{
+		foreach (var syntaxReference in symbol.DeclaringSyntaxReferences)
+		{
+			var syntax = syntaxReference.GetSyntax();
+			switch (syntax)
+			{
+				case VariableDeclaratorSyntax variableDeclarator when variableDeclarator.Initializer != null:
+					yield return variableDeclarator.Initializer.Value;
+					break;
+				case PropertyDeclarationSyntax propertyDeclaration when propertyDeclaration.Initializer != null:
+					yield return propertyDeclaration.Initializer.Value;
+					break;
+				case FieldDeclarationSyntax fieldDeclaration:
+					foreach (var variable in fieldDeclaration.Declaration.Variables)
+					{
+						if (variable.Initializer != null
+							&& SymbolEqualityComparer.Default.Equals(model.GetDeclaredSymbol(variable), symbol))
+						{
+							yield return variable.Initializer.Value;
+						}
+					}
+					break;
+			}
+		}
+
+		foreach (var assignment in root.DescendantNodes().OfType<AssignmentExpressionSyntax>())
+		{
+			if (!SymbolEqualityComparer.Default.Equals(model.GetSymbolInfo(assignment.Left).Symbol, symbol))
+				continue;
+
+			yield return assignment.Right;
+		}
+	}
+
+	private static ExpressionSyntax GetReceiverExpression(InvocationExpressionSyntax invocation)
+	{
+		return invocation.Expression switch
+		{
+			MemberAccessExpressionSyntax memberAccess => memberAccess.Expression,
+			MemberBindingExpressionSyntax => null,
+			IdentifierNameSyntax => null,
+			_ => null
+		};
+	}
+
+	private static ExpressionSyntax Unwrap(ExpressionSyntax expression)
+	{
+		while (expression is ParenthesizedExpressionSyntax parenthesizedExpression)
+		{
+			expression = parenthesizedExpression.Expression;
+		}
+
+		return expression;
+	}
+
+	private static bool IsMethodNamed(InvocationExpressionSyntax invocation, string methodName)
+	{
+		return TryGetInvokedMethodName(invocation, out var invokedMethodName)
+			&& invokedMethodName == methodName;
+	}
+
+	private static bool TryGetInvokedMethodName(InvocationExpressionSyntax invocation, out string methodName)
+	{
+		switch (invocation.Expression)
+		{
+			case MemberAccessExpressionSyntax memberAccess:
+				methodName = memberAccess.Name.Identifier.ValueText;
+				return true;
+			case IdentifierNameSyntax identifierName:
+				methodName = identifierName.Identifier.ValueText;
+				return true;
+			default:
+				methodName = string.Empty;
+				return false;
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add analyzer rule `Mindbox2007` to forbid `AllowAnonymous()` on GraphQL endpoints
- resolve endpoint flows through fluent chains and local variable assignments
- add tests for direct chain, variable-based chain, intermediate variable chain, valid `RequireAuthorization()`, and non-GraphQL endpoints

## Validation
- `dotnet build Mindbox.Analyzers/Mindbox.Analyzers.csproj -p:NoWarn=IDE0370`
- `dotnet build Mindbox.Analyzers.Tests/Mindbox.Analyzers.Tests.csproj -p:NoWarn=IDE0370`

## Notes
- full `dotnet test` was not run locally because .NET 6 runtime is not installed in this environment
- solution-wide build hits a pre-existing `IDE0370` issue in `DataContractRequireIfUsingDataMemberRule.cs`